### PR TITLE
Correct unit

### DIFF
--- a/adafruit_bmp3xx.py
+++ b/adafruit_bmp3xx.py
@@ -193,7 +193,7 @@ class BMP3XX:
 
         pressure = po1 + po2 + pd4
 
-        # pressure in Pa, temperature in deg C
+        # pressure in hPa, temperature in deg C
         return pressure, temperature
 
     def _read_coefficients(self):


### PR DESCRIPTION
The unit returned by the device is hPa not Pa -- based on my device output and information on https://learn.adafruit.com/adafruit-bmp388-bmp390-bmp3xx/python-circuitpython